### PR TITLE
🐛 Fix: 탭별 인사이트 UI 구조 수정

### DIFF
--- a/src/mocks/reportData.ts
+++ b/src/mocks/reportData.ts
@@ -15,30 +15,54 @@ export const reportData: ReportData = {
 
   insightCard: {
     tabs: ['핵심요약', '톤 분석', '근거', '교정'],
+
     items: [
       {
         tab: '핵심요약',
         title: 'Summary On',
-        content:
-          '이번 대화는 전반적으로 Neutral 톤에 가까웠으며, 면접 상황에 비해 개인적인 표현이 비교적 빠르게 등장했습니다.',
+        summary:
+          '이번 대화는 전반적으로 Neutral 톤에 가까웠으며,\n면접 상황에 비해 개인적인 표현이 비교적 빠르게 등장했습니다.',
       },
+
       {
         tab: '톤 분석',
-        title: 'Tone Analysis',
-        content:
-          '전체적으로 차분한 톤이었으나, 일부 문장에서 확신이 낮은 표현이 반복되었습니다.',
+        title: '대화 톤은 어땠을까요?',
+        tones: [
+          {
+            label: '나의 대화 톤',
+            value: 'Neutral',
+          },
+          {
+            label: '상황에 기대된 톤',
+            value: 'Confident',
+          },
+        ],
       },
+
       {
         tab: '근거',
-        title: 'Evidence',
-        content:
-          '"I think maybe..." / "I’m not sure" 표현이 반복되어 자신감이 낮게 전달될 수 있습니다.',
+        title: '이런 점이 보였어요',
+        evidences: [
+          '이 상황에서는 의견을 말하기 전 배경 설명이 자주 사용됩니다.',
+          '이번 대화에서는 결론 중심의 응답이 많았습니다.',
+        ],
       },
+
       {
         tab: '교정',
-        title: 'Correction',
-        content:
-          '"I think maybe" → "I believe"\n"I’m not sure" → "Let me clarify"\n\n확신형 문장으로 교정해보세요.',
+        title: '이 문장을 이렇게 말할 수도 있어요',
+        corrections: [
+          {
+            before: 'I think this will work.',
+            after: 'From our perspective, this approach could be effective.',
+          },
+          {
+            before:
+              'Your background shows a strong fit for user-centered marketing.',
+            after:
+              'Based on our discussion, your background aligns well with user-centered marketing.',
+          },
+        ],
       },
     ],
   },

--- a/src/pages/my-report/detail/components/ReportAI/AICard/Content/Content.tsx
+++ b/src/pages/my-report/detail/components/ReportAI/AICard/Content/Content.tsx
@@ -1,19 +1,39 @@
 import type { InsightItem } from '@/pages/my-report/detail/types/report.type';
 
+import Correction from './Correction/Correction';
+import Evidence from './Evidence/Evidence';
+import Summary from './Summary/Summary';
+import ToneAnalysis from './ToneAnalysis/ToneAnalysis';
+
 interface ContentProps {
   item?: InsightItem;
 }
 
+const renderContent = (item: InsightItem) => {
+  switch (item.tab) {
+    case '핵심요약':
+      return <Summary item={item} />;
+
+    case '톤 분석':
+      return <ToneAnalysis item={item} />;
+
+    case '근거':
+      return <Evidence item={item} />;
+
+    case '교정':
+      return <Correction item={item} />;
+
+    default:
+      return null;
+  }
+};
+
 const Content = ({ item }: ContentProps) => {
+  if (!item) return null;
+
   return (
     <div className="w-full flex flex-col gap-[1.6rem] rounded-2xl border-[0.1rem] border-gray-100 bg-white pl-[2.4rem] pr-[4.7rem] py-[2.6rem]">
-      <p className="font-bold text-[1.5rem] leading-none text-purple-900">
-        {item?.title}
-      </p>
-
-      <p className="text-[1.4rem] leading-[1.5] text-black font-medium whitespace-pre-line">
-        {item?.content}
-      </p>
+      {renderContent(item)}
     </div>
   );
 };

--- a/src/pages/my-report/detail/components/ReportAI/AICard/Content/Correction/Correction.tsx
+++ b/src/pages/my-report/detail/components/ReportAI/AICard/Content/Correction/Correction.tsx
@@ -1,0 +1,29 @@
+import type { CorrectionInsightItem } from '@/pages/my-report/detail/types/report.type';
+
+const Correction = ({ item }: { item: CorrectionInsightItem }) => {
+  return (
+    <>
+      <p className="font-bold text-[1.5rem] text-purple-900">{item.title}</p>
+
+      <div className="flex flex-col gap-[1.6rem]">
+        {item.corrections.map((c, idx) => (
+          <div key={idx}>
+            <div className="flex items-start gap-[0.9rem]">
+              <span className="mt-[0.9rem] block h-[0.4rem] w-[0.4rem] rounded-full bg-black" />
+              <p className="text-[1.4rem] font-medium leading-[1.4] text-black">
+                {c.before}
+              </p>
+            </div>
+
+            <div className="ml-[1.3rem] mt-[1rem] flex items-start gap-[0.6rem] text-[1.4rem] font-medium leading-[1.4] text-purple-900">
+              <p>→</p>
+              <p>{c.after}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default Correction;

--- a/src/pages/my-report/detail/components/ReportAI/AICard/Content/Evidence/Evidence.tsx
+++ b/src/pages/my-report/detail/components/ReportAI/AICard/Content/Evidence/Evidence.tsx
@@ -1,0 +1,22 @@
+import type { EvidenceInsightItem } from '@/pages/my-report/detail/types/report.type';
+
+const Evidence = ({ item }: { item: EvidenceInsightItem }) => {
+  return (
+    <>
+      <p className="font-bold text-[1.5rem] text-purple-900">{item.title}</p>
+
+      <ul className="pl-[0.5rem] space-y-[0.9rem]">
+        {item.evidences.map((e, idx) => (
+          <li key={idx} className="flex items-start gap-[0.9rem]">
+            <span className="mt-[0.9rem] block h-[0.4rem] w-[0.4rem] rounded-full bg-black" />
+            <p className="text-[1.4rem] font-medium leading-[1.5] text-black">
+              {e}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+export default Evidence;

--- a/src/pages/my-report/detail/components/ReportAI/AICard/Content/Summary/Summary.tsx
+++ b/src/pages/my-report/detail/components/ReportAI/AICard/Content/Summary/Summary.tsx
@@ -1,0 +1,10 @@
+import type { SummaryInsightItem } from '@/pages/my-report/detail/types/report.type';
+
+const Summary = ({ item }: { item: SummaryInsightItem }) => (
+  <>
+    <p className="font-bold text-[1.5rem] text-purple-900">{item.title}</p>
+    <p className="text-[1.4rem] leading-[1.5]">{item.summary}</p>
+  </>
+);
+
+export default Summary;

--- a/src/pages/my-report/detail/components/ReportAI/AICard/Content/ToneAnalysis/ToneAnalysis.tsx
+++ b/src/pages/my-report/detail/components/ReportAI/AICard/Content/ToneAnalysis/ToneAnalysis.tsx
@@ -1,0 +1,38 @@
+import clsx from 'clsx';
+
+import type { ToneAnalysisInsightItem } from '@/pages/my-report/detail/types/report.type';
+
+const ToneAnalysis = ({ item }: { item: ToneAnalysisInsightItem }) => {
+  return (
+    <>
+      <p className="font-bold text-[1.5rem] text-purple-900">{item.title}</p>
+
+      <div className="flex flex-col gap-[0.8rem]">
+        {item.tones.map((tone, idx) => {
+          const hasValue = Boolean(tone.value);
+
+          return (
+            <div key={idx} className="flex items-center gap-[1.3rem]">
+              <p className="text-[1.4rem] font-medium leading-[1.5] text-black">
+                {tone.label}
+              </p>
+
+              <div
+                className={clsx(
+                  'py-[0.9rem] rounded-full border-[0.1rem] text-[1.4rem] font-medium leading-none',
+                  hasValue
+                    ? 'px-[1.6rem] border-purple-500 text-purple-600'
+                    : 'px-[1.8rem] border-gray-200 bg-gray-50 text-gray-400',
+                )}
+              >
+                {hasValue ? tone.value : '?'}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+};
+
+export default ToneAnalysis;

--- a/src/pages/my-report/detail/types/report.type.ts
+++ b/src/pages/my-report/detail/types/report.type.ts
@@ -9,11 +9,41 @@ export type ReportMeta = {
 
 export type InsightTab = '핵심요약' | '톤 분석' | '근거' | '교정';
 
-export type InsightItem = {
-  tab: InsightTab;
+export type SummaryInsightItem = {
+  tab: '핵심요약';
   title: string;
-  content: string;
+  summary: string;
 };
+
+export type ToneAnalysisInsightItem = {
+  tab: '톤 분석';
+  title: string;
+  tones: {
+    label: string;
+    value: string;
+  }[];
+};
+
+export type EvidenceInsightItem = {
+  tab: '근거';
+  title: string;
+  evidences: string[];
+};
+
+export type CorrectionInsightItem = {
+  tab: '교정';
+  title: string;
+  corrections: {
+    before: string;
+    after: string;
+  }[];
+};
+
+export type InsightItem =
+  | SummaryInsightItem
+  | ToneAnalysisInsightItem
+  | EvidenceInsightItem
+  | CorrectionInsightItem;
 
 export type InsightCard = {
   tabs: InsightTab[];


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close #48 

## 📝 작업 내용
- 인사이트 카드 탭별로 UI가 다르게 렌더링되도록 수정
- Summary / ToneAnalysis / Evidence / Correction 컴포넌트 분리 및 적용
- 데이터 구조 및 타입 정의 개선

## 📌 공유 사항
- 320px 환경에서 말풍선 UI가 깨지는 이슈가 있어, 추후 디자인 가이드가 나오면 반영하여 수정 예정
<img width="1512" height="982" alt="스크린샷 2026-01-30 오후 10 32 35" src="https://github.com/user-attachments/assets/51106195-f380-4178-bd9f-449edcfbe566" />

## ✅ 체크리스트
- [X] Reviewer에 팀원들을 선택 했나요?
- [X] Assignees에 본인을 선택 했나요?
- [X] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [X] 컨벤션을 지키고 있나요?
- [X] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [X] 불필요한 주석이 제거되었나요?
- [X] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
https://github.com/user-attachments/assets/21793412-6e23-40c4-9076-25501ecd8452


## 💬 리뷰 요구사항 (선택)
