### PR TITLE
🐛 Fix: 대화 세션 생성 후 경로 이동 및 state 값 변경

### DIFF
--- a/src/pages/my-speak/setting/components/ChatSetting.tsx
+++ b/src/pages/my-speak/setting/components/ChatSetting.tsx
@@ -23,8 +23,8 @@ const ChatSetting = () => {
       // console.log('sessionId:', sessionId);
       alert('대화 세션이 생성되었습니다.');
 
-      navigateTo('/my-speak/interview', {
-        state: { sessionId },
+      navigateTo(`/my-speak/interview/${sessionId}`, {
+        state: { myRoleId: selectedAIId },
       });
     },
   });


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #51 

## 📝 작업 내용
- 대화 세션 생성 후 이동되는 경로와 state 값을 변경하였습니다.

## 📌 공유 사항
- router.tsx의 /my-speak/interview/:id로 경로 바꿔주시면 감사하겠습니다!

## ✅ 체크리스트
- [X] Reviewer에 팀원들을 선택 했나요?
- [X] Assignees에 본인을 선택 했나요?
- [X] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [X] 컨벤션을 지키고 있나요?
- [X] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [X] 불필요한 주석이 제거되었나요?
- [X] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="934" height="226" alt="image" src="https://github.com/user-attachments/assets/874b3a5b-bd4a-435c-a94d-688fdbffb154" />

## 💬 리뷰 요구사항 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등
