### PR TITLE
✨ Feat: mySpeak 결과페이지 API 연동

### DIFF
--- a/src/mocks/resultData.ts
+++ b/src/mocks/resultData.ts
@@ -1,6 +1,0 @@
-import type { ResultProps } from '@/pages/my-speak/result/types/result.type';
-
-export const resultData: ResultProps = {
-  timeText: '12분 30초',
-  sentenceText: '18문장',
-};

--- a/src/pages/my-report/detail/Detail.tsx
+++ b/src/pages/my-report/detail/Detail.tsx
@@ -32,10 +32,12 @@ const Detail = () => {
 
   // 최초 렌더 초기화
   if (report && difficulty === null) {
+    const safeReview = report.userReflection ?? '';
+
     setDifficulty(report.sessionSummary.difficulty);
-    setReview(report.userReflection);
+    setReview(safeReview);
     setInitialDifficulty(report.sessionSummary.difficulty);
-    setInitialReview(report.userReflection);
+    setInitialReview(safeReview);
   }
 
   const isDirty =

--- a/src/pages/my-report/detail/components/ReportAI/ReportAI.tsx
+++ b/src/pages/my-report/detail/components/ReportAI/ReportAI.tsx
@@ -11,6 +11,12 @@ interface ReportAIProps {
 }
 
 const ReportAI = ({ data }: ReportAIProps) => {
+  console.log(data);
+  const toneAnalysis = data.toneAnalysis ?? {
+    userTone: null,
+    expectedTone: null,
+  };
+
   const insightCard: InsightCard = {
     tabs: ['핵심요약', '톤 분석', '근거', '교정'],
     items: [
@@ -25,11 +31,11 @@ const ReportAI = ({ data }: ReportAIProps) => {
         tones: [
           {
             label: '나의 대화 톤',
-            value: data.toneAnalysis.userTone,
+            value: toneAnalysis.userTone ?? 'None',
           },
           {
             label: '상황에 기대된 톤',
-            value: data.toneAnalysis.expectedTone,
+            value: toneAnalysis.expectedTone ?? 'None',
           },
         ],
       },

--- a/src/pages/my-report/detail/components/ReportChat/ChatCard/ItemChat.tsx
+++ b/src/pages/my-report/detail/components/ReportChat/ChatCard/ItemChat.tsx
@@ -23,7 +23,7 @@ const ItemChat = ({ chat }: ItemChatProps) => {
           <img
             src={chat.avatarUrl}
             alt={chat.speakerName}
-            className="w-16 h-16 rounded-full border-[0.1rem] border-gray-100 shrink-0"
+            className="w-16 h-16 rounded-full border-[0.1rem] border-gray-100 shrink-0 object-cover"
           />
         )}
 

--- a/src/pages/my-report/detail/components/ReportInfo/ReviewCard/ReviewCard.tsx
+++ b/src/pages/my-report/detail/components/ReportInfo/ReviewCard/ReviewCard.tsx
@@ -17,9 +17,10 @@ const ReviewCard = ({
 }: ReviewCardProps) => {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
+  const safeText = text ?? '';
   const countText = useMemo(
-    () => `${Math.min(text.length, maxLength)}/${maxLength}`,
-    [text, maxLength],
+    () => `${Math.min(safeText.length, maxLength)}/${maxLength}`,
+    [safeText, maxLength],
   );
 
   const handleChange = (v: string) => {

--- a/src/pages/my-speak/result/Result.tsx
+++ b/src/pages/my-speak/result/Result.tsx
@@ -25,6 +25,7 @@ const Result = () => {
   }, [location.state, navigateTo]);
 
   const { createReport, isLoading: isCreating } = useCreateReport(() => {
+    alert('리포트가 생성되었습니다.');
     navigateTo(`/my-report/${sessionId}`);
   });
 

--- a/src/pages/my-speak/result/Result.tsx
+++ b/src/pages/my-speak/result/Result.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom';
 
 import RightArrow from '@/assets/images/icons/right-arrow.svg';
 import useNavigation from '@/hooks/useNavigation';
+import { formatTime } from '@/utils/date';
 
 import StarRating from '../../../components/StarRating/StarRating';
 import ListCard from './components/Card/ListCard/ListCard';
@@ -26,7 +27,7 @@ const Result = () => {
 
   const { createReport, isLoading: isCreating } = useCreateReport(() => {
     alert('리포트가 생성되었습니다.');
-    navigateTo(`/my-report/${sessionId}`);
+    navigateTo('/my-report/');
   });
 
   const { save, isLoading: isSaving } = useSave(() => {
@@ -46,7 +47,10 @@ const Result = () => {
     <div className="flex flex-col w-full px-[1.55rem] pb-[17.72rem]">
       <Header />
 
-      <ListCard timeText={totalTime} sentenceText={sentenceCount}>
+      <ListCard
+        timeText={formatTime(totalTime)}
+        sentenceText={`${sentenceCount} 문장`}
+      >
         <StarRating value={rating} onChange={setRating} />
       </ListCard>
 

--- a/src/pages/my-speak/result/Result.tsx
+++ b/src/pages/my-speak/result/Result.tsx
@@ -1,33 +1,57 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import RightArrow from '@/assets/images/icons/right-arrow.svg';
 import useNavigation from '@/hooks/useNavigation';
-import { resultData } from '@/mocks/resultData';
 
 import StarRating from '../../../components/StarRating/StarRating';
 import ListCard from './components/Card/ListCard/ListCard';
 import Header from './components/Header/Header';
+import { useCreateReport } from './hooks/useCreateReport';
+import { useSave } from './hooks/useSave';
 
 const Result = () => {
   const [rating, setRating] = useState(0);
-  const { timeText, sentenceText } = resultData;
   const { navigateTo } = useNavigation();
 
+  const location = useLocation();
+  const { sessionId, totalTime, sentenceCount } = location.state || {};
+
+  useEffect(() => {
+    if (!location.state) {
+      alert('세션 정보가 없어 설정 화면으로 이동합니다.');
+      navigateTo('/my-speak/setting');
+    }
+  }, [location.state, navigateTo]);
+
+  const { createReport, isLoading: isCreating } = useCreateReport(() => {
+    navigateTo(`/my-report/${sessionId}`);
+  });
+
+  const { save, isLoading: isSaving } = useSave(() => {
+    createReport({ sessionId });
+  });
+
   const handleReportClick = () => {
-    navigateTo('/my-report');
+    if (rating < 1 || rating > 5) return;
+
+    save({
+      sessionId,
+      userDifficulty: rating,
+    });
   };
 
   return (
     <div className="flex flex-col w-full px-[1.55rem] pb-[17.72rem]">
       <Header />
 
-      <ListCard timeText={timeText} sentenceText={sentenceText}>
+      <ListCard timeText={totalTime} sentenceText={sentenceCount}>
         <StarRating value={rating} onChange={setRating} />
       </ListCard>
 
       <button
         className="flex justify-center gap-[1.2rem] mt-[2.492rem] w-full rounded-2xl bg-purple-700 py-[1.4rem] text-[1.6rem] font-semibold text-white"
-        disabled={rating === 0}
+        disabled={rating === 0 || isSaving || isCreating}
         onClick={handleReportClick}
       >
         리포트 확인하기

--- a/src/pages/my-speak/result/hooks/useCreateReport.ts
+++ b/src/pages/my-speak/result/hooks/useCreateReport.ts
@@ -1,0 +1,29 @@
+import { useMutation } from '@/hooks/useApi';
+import type { ReportDetailResult } from '@/types/api/myreport.type';
+import type { ServerApiResponse } from '@/types/api/server.type';
+
+export const useCreateReport = (
+  onSuccess?: (data: ReportDetailResult) => void,
+) => {
+  const { mutate, isLoading, isError, error } = useMutation<
+    ServerApiResponse<ReportDetailResult>,
+    { sessionId: number }
+  >(
+    ({ sessionId }) => ({
+      method: 'POST',
+      url: `/reports/sessions/${sessionId}`,
+    }),
+    {
+      onSuccess: (res) => {
+        onSuccess?.(res.result);
+      },
+    },
+  );
+
+  return {
+    createReport: mutate,
+    isLoading,
+    isError,
+    error,
+  };
+};

--- a/src/pages/my-speak/result/hooks/useSave.ts
+++ b/src/pages/my-speak/result/hooks/useSave.ts
@@ -1,0 +1,29 @@
+import { useMutation } from '@/hooks/useApi';
+import type { SaveRequest } from '@/types/api/myspeak.type';
+import type { ServerApiResponse } from '@/types/api/server.type';
+
+export const useSave = (onSuccess?: () => void) => {
+  const { mutate, data, isLoading, isError, error } = useMutation<
+    ServerApiResponse<void>,
+    SaveRequest
+  >(
+    ({ sessionId, userDifficulty }) => ({
+      method: 'POST',
+      url: `/myspeak/sessions/${sessionId}/difficulty`,
+      data: {
+        userDifficulty,
+      },
+    }),
+    {
+      onSuccess,
+    },
+  );
+
+  return {
+    save: mutate,
+    data: data?.result ?? null,
+    isLoading,
+    isError,
+    error,
+  };
+};

--- a/src/types/api/myreport.type.ts
+++ b/src/types/api/myreport.type.ts
@@ -25,9 +25,9 @@ export interface ReportDetailResult {
     aiSummary: string;
 
     toneAnalysis: {
-      userTone: string;
-      expectedTone: string;
-    };
+      userTone: string | null;
+      expectedTone: string | null;
+    } | null;
 
     aiReason: string[];
 
@@ -38,7 +38,7 @@ export interface ReportDetailResult {
     }[];
   };
 
-  userReflection: string;
+  userReflection: string | null;
 
   conversationLog: ReportLogResult[];
 }

--- a/src/types/api/myspeak.type.ts
+++ b/src/types/api/myspeak.type.ts
@@ -76,3 +76,9 @@ export interface TTSCacheItem {
 export interface GetTTSCacheResponse {
   cachedAudios: TTSCacheItem[];
 }
+
+// 결과 - 난이도 저장 요청
+export interface SaveRequest {
+  sessionId: number;
+  userDifficulty: number;
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -3,3 +3,9 @@ export const formatDate = (iso?: string | null): string => {
 
   return new Date(iso).toLocaleDateString('ko-KR');
 };
+
+export const formatTime = (seconds: number) => {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -5,7 +5,9 @@ export const formatDate = (iso?: string | null): string => {
 };
 
 export const formatTime = (seconds: number) => {
-  const m = Math.floor(seconds / 60);
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
   const s = seconds % 60;
-  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+
+  return [h, m, s].map((v) => String(v).padStart(2, '0')).join(':');
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close #70 

## 📝 작업 내용
- state로 받은 값 UI에 표시
- 난이도 저장 API 연동
- 대화로그 분석하여 리포트 생성 API 연동

## 📌 공유 사항
- types/api/myspeak.type.ts에 Result 페이지에서 사용하는 난이도 저장 관련 타입을 추가했습니다.
- myReport 상세페이지에서 null 값 관련 오류 있어 수정했습니다.

## ✅ 체크리스트
- [X] Reviewer에 팀원들을 선택 했나요?
- [X] Assignees에 본인을 선택 했나요?
- [X] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [X] 컨벤션을 지키고 있나요?
- [X] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [X] 불필요한 주석이 제거되었나요?
- [X] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

https://github.com/user-attachments/assets/f9380c4b-d3aa-48d8-8a63-9581d16faeb0


## 💬 리뷰 요구사항 (선택)
