### PR TITLE
♻️ Refactor: myReport 상세페이지 로직 변경

### DIFF
--- a/src/pages/my-report/detail/Detail.tsx
+++ b/src/pages/my-report/detail/Detail.tsx
@@ -17,7 +17,7 @@ const Detail = () => {
   const { id } = useParams<{ id: string }>();
   const reportId = id ? Number(id) : undefined;
 
-  const { report, isLoading, isError } = useReportDetail(reportId);
+  const { report, isLoading, isError, refetch } = useReportDetail(reportId);
   const { mutate: updateReflection, isLoading: isSaving } = useReportUpdate();
   const { setReport, reset } = useReportDetailStore();
 
@@ -31,8 +31,14 @@ const Detail = () => {
     return () => reset();
   }, [report, setReport, reset]);
 
+  const isInitialLoading = isLoading && !report;
+
   const handleSave = async () => {
-    if (!report || difficulty === undefined) return;
+    if (!report) return;
+
+    const difficulty = draft.difficulty ?? report.sessionSummary.difficulty;
+
+    const review = draft.review ?? report.userReflection ?? '';
 
     const result = await updateReflection({
       reportId: report.reportId,
@@ -41,67 +47,84 @@ const Detail = () => {
     });
 
     if (result !== null) {
+      await refetch();
       alert('저장되었습니다.');
       setDraft({});
     }
   };
 
-  if (isLoading) {
-    return (
-      <div className="flex justify-center items-center min-h-[60vh]">
-        <Spinner color="var(--color-purple-700)" />
-      </div>
-    );
-  }
-
-  if (isError || !report) {
-    return (
-      <div className="flex justify-center items-center py-[6rem] text-gray-400">
-        리포트를 불러올 수 없습니다.
-      </div>
-    );
-  }
-
-  const difficulty = draft.difficulty ?? report.sessionSummary.difficulty;
-
-  const review = draft.review ?? report.userReflection ?? '';
-
-  const isDirty =
-    difficulty !== report.sessionSummary.difficulty ||
-    review !== (report.userReflection ?? '');
-
   return (
     <>
       <PrevNavbar
-        title={`${report.sessionSummary.job} 직무 ${report.sessionSummary.situation}`}
+        title={
+          report
+            ? `${report.sessionSummary.job} 직무 ${report.sessionSummary.situation}`
+            : ''
+        }
         path="/my-report"
       />
 
-      <div className="white-pageContainer pr-[1.597rem] gap-[3.3rem]">
-        <ReportInfo
-          data={report.sessionSummary}
-          difficulty={difficulty}
-          review={review}
-          onChangeDifficulty={(value) =>
-            setDraft((prev) => ({ ...prev, difficulty: value }))
-          }
-          onChangeReview={(value) =>
-            setDraft((prev) => ({ ...prev, review: value }))
-          }
-        />
+      <div className="relative white-pageContainer pr-[1.597rem] gap-[3.3rem]">
+        {isInitialLoading && (
+          <div className="absolute inset-0 flex justify-center items-center z-10">
+            <Spinner color="var(--color-purple-700)" />
+          </div>
+        )}
 
-        <ReportBar />
-        <ReportAI data={report.aiInsightCard} />
-        <ReportBar />
+        {isError && !isLoading && (
+          <div className="flex justify-center items-center py-[6rem] text-gray-400">
+            리포트를 불러올 수 없습니다.
+          </div>
+        )}
 
-        <ReportChat />
+        {report && (
+          <>
+            {(() => {
+              const difficulty =
+                draft.difficulty ?? report.sessionSummary.difficulty;
 
-        {isDirty && (
-          <ReportButton
-            text={isSaving ? '저장 중...' : '저장하기'}
-            onClick={handleSave}
-            disabled={isSaving}
-          />
+              const review = draft.review ?? report.userReflection ?? '';
+
+              const isDirty =
+                difficulty !== report.sessionSummary.difficulty ||
+                review !== (report.userReflection ?? '');
+
+              return (
+                <>
+                  <ReportInfo
+                    data={report.sessionSummary}
+                    difficulty={difficulty}
+                    review={review}
+                    onChangeDifficulty={(value) =>
+                      setDraft((prev) => ({
+                        ...prev,
+                        difficulty: value,
+                      }))
+                    }
+                    onChangeReview={(value) =>
+                      setDraft((prev) => ({
+                        ...prev,
+                        review: value,
+                      }))
+                    }
+                  />
+
+                  <ReportBar />
+                  <ReportAI data={report.aiInsightCard} />
+                  <ReportBar />
+                  <ReportChat />
+
+                  {isDirty && (
+                    <ReportButton
+                      text={isSaving ? '저장 중...' : '저장하기'}
+                      onClick={handleSave}
+                      disabled={isSaving}
+                    />
+                  )}
+                </>
+              );
+            })()}
+          </>
         )}
       </div>
     </>

--- a/src/pages/my-report/detail/components/ReportAI/AICard/Content/Correction/Correction.tsx
+++ b/src/pages/my-report/detail/components/ReportAI/AICard/Content/Correction/Correction.tsx
@@ -1,26 +1,39 @@
 import type { CorrectionInsightItem } from '@/pages/my-report/detail/types/myreport.type';
 
 const Correction = ({ item }: { item: CorrectionInsightItem }) => {
+  const isEmpty = !item.corrections || item.corrections.length === 0;
+
   return (
     <>
       <p className="font-bold text-[1.5rem] text-purple-900">{item.title}</p>
 
-      <div className="flex flex-col gap-[1.6rem]">
-        {item.corrections.map((c, idx) => (
-          <div key={idx}>
+      <div className="pl-[0.5rem] flex flex-col gap-[1.6rem]">
+        {isEmpty ? (
+          <div>
             <div className="flex items-start gap-[0.9rem]">
               <span className="mt-[0.9rem] block h-[0.4rem] w-[0.4rem] rounded-full bg-black" />
               <p className="text-[1.4rem] font-medium leading-[1.4] text-black">
-                {c.before}
+                교정할 내용이 없습니다.
               </p>
             </div>
-
-            <div className="ml-[1.3rem] mt-[1rem] flex items-start gap-[0.6rem] text-[1.4rem] font-medium leading-[1.4] text-purple-900">
-              <p>→</p>
-              <p>{c.after}</p>
-            </div>
           </div>
-        ))}
+        ) : (
+          item.corrections.map((c, idx) => (
+            <div key={idx}>
+              <div className="flex items-start gap-[0.9rem]">
+                <span className="mt-[0.9rem] block h-[0.4rem] w-[0.4rem] rounded-full bg-black" />
+                <p className="text-[1.4rem] font-medium leading-[1.4] text-black">
+                  {c.before}
+                </p>
+              </div>
+
+              <div className="ml-[1.3rem] mt-[1rem] flex items-start gap-[0.6rem] text-[1.4rem] font-medium leading-[1.4] text-purple-900">
+                <p>→</p>
+                <p>{c.after}</p>
+              </div>
+            </div>
+          ))
+        )}
       </div>
     </>
   );

--- a/src/pages/my-report/detail/components/ReportAI/AICard/Content/Summary/Summary.tsx
+++ b/src/pages/my-report/detail/components/ReportAI/AICard/Content/Summary/Summary.tsx
@@ -3,7 +3,7 @@ import type { SummaryInsightItem } from '@/pages/my-report/detail/types/myreport
 const Summary = ({ item }: { item: SummaryInsightItem }) => (
   <>
     <p className="font-bold text-[1.5rem] text-purple-900">{item.title}</p>
-    <p className="text-[1.4rem] leading-[1.5]">{item.summary}</p>
+    <p className="text-[1.4rem] leading-[1.5] font-medium">{item.summary}</p>
   </>
 );
 

--- a/src/pages/my-report/detail/components/ReportChat/ChatCard/ChatCard.tsx
+++ b/src/pages/my-report/detail/components/ReportChat/ChatCard/ChatCard.tsx
@@ -14,8 +14,8 @@ const ChatCard = ({ data, isLocked, isLoading }: ChatCardProps) => {
   return (
     <div className="relative w-full h-[49rem] rounded-2xl border border-gray-100 bg-white overflow-hidden [overflow-anchor:none] will-change-transform translate-z-0">
       <div className="h-full overflow-y-auto flex flex-col gap-8 px-[1.25rem] py-[1.492rem]">
-        {data.map((chat) => (
-          <ItemChat key={chat.id} chat={chat} />
+        {data.map((chat, index) => (
+          <ItemChat key={`${chat.id ?? 'chat'}-${index}`} chat={chat} />
         ))}
       </div>
 

--- a/src/pages/my-report/detail/components/ReportChat/ChatCard/LockedOverlay.tsx
+++ b/src/pages/my-report/detail/components/ReportChat/ChatCard/LockedOverlay.tsx
@@ -6,7 +6,7 @@ const LockedOverlay = () => {
   const { navigateTo } = useNavigation();
 
   return (
-    <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/40">
+    <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/50 backdrop-blur-sm">
       <div className="flex flex-col items-center text-white">
         <img
           src={Lock}

--- a/src/pages/my-report/detail/components/ReportChat/ReportChat.tsx
+++ b/src/pages/my-report/detail/components/ReportChat/ReportChat.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { useReportDetailStore } from '@/stores/my-report/detail.store';
 
 import { useReportLogs } from '../../hooks/useReportLogs';
@@ -9,6 +11,16 @@ const ReportChat = () => {
   const reportId = report?.reportId;
 
   const { logs, isLoading } = useReportLogs(reportId);
+
+  useEffect(() => {
+    if (!reportId) return;
+
+    const key = `report-${reportId}`;
+
+    return () => {
+      sessionStorage.removeItem(key);
+    };
+  }, [reportId]);
 
   const chatLogs = logs.map((log) => ({
     id: log.messageId,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close #74 

## 📝 작업 내용
- sessionStorage 기반 viewUUID 생성 방식 유지하되, 페이지 이탈 시 UUID 제거하도록 수정
  - 새로고침 시에는 차감되지 않음
  - 페이지를 나갔다가 재진입하면 새로운 UUID 생성 → 정상 차감
- Chat 로그 key 중복 오류 수정

## 📌 공유 사항

## ✅ 체크리스트
- [X] Reviewer에 팀원들을 선택 했나요?
- [X] Assignees에 본인을 선택 했나요?
- [X] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [X] 컨벤션을 지키고 있나요?
- [X] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [X] 불필요한 주석이 제거되었나요?
- [X] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="363" height="652" alt="스크린샷 2026-02-12 오전 1 25 40" src="https://github.com/user-attachments/assets/7ad6064c-45bd-4c64-ac16-7f6a12d6beda" />

## 💬 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed chat item key generation with improved fallback handling
  * Added automatic session storage cleanup when component unmounts
  * Added empty state message for missing corrections data

* **Improvements**
  * Enhanced loading state display with full-page overlay spinner
  * Improved error handling and user messaging
  * Refined save flow with automatic data refresh

* **Style**
  * Enhanced overlay visual appearance with increased opacity and blur effect
  * Updated summary text styling for improved emphasis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->