### PR TITLE
🐛 Fix: mySpeak 세팅페이지 오류 수정

### DIFF
--- a/src/pages/my-role/components/Add/Step/Step1/ListStep1.tsx
+++ b/src/pages/my-role/components/Add/Step/Step1/ListStep1.tsx
@@ -11,7 +11,7 @@ const ListStep1 = ({ selectedId, onSelect }: ListStep1Props) => {
   const { avatars } = useAvatar();
 
   return (
-    <div className="w-full flex gap-3 overflow-x-auto">
+    <div className="w-full flex gap-3 overflow-x-auto scroll">
       {avatars?.map((avatar) => (
         <ItemStep1
           key={avatar.id}

--- a/src/pages/my-role/components/Favs/NotFavs.tsx
+++ b/src/pages/my-role/components/Favs/NotFavs.tsx
@@ -1,9 +1,29 @@
-const NotFavs = () => {
+import useNavigation from '@/hooks/useNavigation';
+
+type NotFavsProps = {
+  locationText?: string;
+  moveTo?: string;
+};
+
+const NotFavs = ({ locationText = '아래에서', moveTo }: NotFavsProps) => {
+  const { navigateTo } = useNavigation();
+
+  const handleClick = () => {
+    if (!moveTo) return;
+    navigateTo(moveTo);
+  };
+
   return (
-    <div className="w-full flex flex-col gap-2 items-center text-center text-[1.2rem] text-gray-400">
+    <div className="w-full flex flex-col gap-2 items-center text-center text-[1.2rem] text-gray-400 pr-[1.462rem]">
       <p className="font-bold leading-[1.4]">아직 설정된 상대 역할이 없어요</p>
       <p className="font-medium leading-[1.35]">
-        아래에서 사람 · 직무 · 상황을 선택해
+        <span
+          className={moveTo ? 'cursor-pointer underline' : ''}
+          onClick={handleClick}
+        >
+          {locationText}
+        </span>{' '}
+        사람 · 직무 · 상황을 선택해
         <br />
         연습할 상대를 미리 만들어보세요
       </p>

--- a/src/pages/my-speak/result/Result.tsx
+++ b/src/pages/my-speak/result/Result.tsx
@@ -46,7 +46,7 @@ const Result = () => {
   const isLoading = isSaving || isCreating;
 
   return (
-    <div className="flex flex-col w-full px-[1.55rem] pb-[17.72rem]">
+    <div className="flex flex-col w-full px-[1.55rem]">
       <Header />
 
       <ListCard

--- a/src/pages/my-speak/result/components/Header/Header.tsx
+++ b/src/pages/my-speak/result/components/Header/Header.tsx
@@ -10,7 +10,7 @@ const NAV_ITEMS = [
 
 const Header = () => {
   return (
-    <div className="w-full flex justify-center mt-[9.858rem] mb-[8.482rem]">
+    <div className="w-full flex justify-center mt-[clamp(3rem,10vh,9.858rem)] mb-[clamp(2.5rem,8vh,8.482rem)]">
       <p className="relative font-bold text-[2.4rem] text-white">
         수고하셨어요!
         {NAV_ITEMS.map((item, idx) => (

--- a/src/pages/my-speak/setting/components/ChatSetting.tsx
+++ b/src/pages/my-speak/setting/components/ChatSetting.tsx
@@ -4,6 +4,7 @@ import RoleProfileList from '@/components/RoleProfile/ListRoleProfile';
 import { useRoleProfile } from '@/hooks/role-profile/useRoleProfile';
 import useNavigation from '@/hooks/useNavigation';
 import { goalData } from '@/mocks/settingData';
+import NotFavs from '@/pages/my-role/components/Favs/NotFavs';
 import { useCreateSession } from '@/pages/my-speak/setting/hooks/useCreateSession';
 
 import ListGoal from './Step/Goal/ListGoal';
@@ -49,11 +50,17 @@ const ChatSetting = () => {
           title="AI 롤 선택"
           done={selectedAIId !== null}
         >
-          <RoleProfileList
-            data={profiles}
-            selectedId={selectedAIId}
-            onSelect={setSelectedAIId}
-          />
+          {!profiles || profiles.length === 0 ? (
+            <div className="w-full pr-[1.462rem]">
+              <NotFavs locationText="My Role에서" moveTo="/my-role" />
+            </div>
+          ) : (
+            <RoleProfileList
+              data={profiles}
+              selectedId={selectedAIId}
+              onSelect={setSelectedAIId}
+            />
+          )}
         </StepSection>
 
         {selectedAIId !== null && (

--- a/src/pages/onboarding/components/Step/Step5.tsx
+++ b/src/pages/onboarding/components/Step/Step5.tsx
@@ -32,7 +32,7 @@ const Step5 = () => {
             onClick={complete}
             disabled={isLoading}
           >
-            {isLoading ? '처리 중...' : '시작하기'}
+            시작하기
           </button>
         </div>
       </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close #86 

## 📝 작업 내용
- AI 롤 데이터가 없을 경우 Step UI 내부에 아무것도 렌더링되지 않던 문제 수정
- profiles.length === 0 조건 분기 처리하여 Empty UI 노출하도록 개선
- NotFavs 컴포넌트에 locationText, moveTo props 추가하여 재사용성 및 이동 기능 확장
- Result 페이지 상단 Header 여백을 clamp() 기반 반응형 마진으로 개선

## 📌 공유 사항
- Empty 상태는 Step 구조를 유지한 상태에서 UI만 대체했습니다.

## ✅ 체크리스트
- [X] Reviewer에 팀원들을 선택 했나요?
- [X] Assignees에 본인을 선택 했나요?
- [X] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [X] 컨벤션을 지키고 있나요?
- [X] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [X] 불필요한 주석이 제거되었나요?
- [X] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="437" height="739" alt="스크린샷 2026-02-12 오후 3 38 53" src="https://github.com/user-attachments/assets/7caab345-ec7a-4e80-8eee-de0d8b1ee24f" />

## 💬 리뷰 요구사항 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clickable navigation to the favorites section
  * Implemented fallback UI display when no profiles are available

* **Style**
  * Enhanced responsive spacing calculations in headers with improved viewport adaptation
  * Refined padding and scroll behaviors across pages
  * Updated button text display behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->