### PR TITLE
🐛 Fix: uuid 이중 생성 오류 수정

### DIFF
--- a/src/pages/my-report/detail/Detail.tsx
+++ b/src/pages/my-report/detail/Detail.tsx
@@ -17,7 +17,9 @@ const Detail = () => {
   const { id } = useParams<{ id: string }>();
   const reportId = id ? Number(id) : undefined;
 
-  const { report, isLoading, isError, refetch } = useReportDetail(reportId);
+  const { report, viewUUID, isLoading, isError, refetch } =
+    useReportDetail(reportId);
+
   const { mutate: updateReflection, isLoading: isSaving } = useReportUpdate();
   const { setReport, reset } = useReportDetailStore();
 
@@ -112,7 +114,7 @@ const Detail = () => {
                   <ReportBar />
                   <ReportAI data={report.aiInsightCard} />
                   <ReportBar />
-                  <ReportChat />
+                  <ReportChat viewUUID={viewUUID} />
 
                   {isDirty && (
                     <ReportButton

--- a/src/pages/my-report/detail/components/ReportChat/ReportChat.tsx
+++ b/src/pages/my-report/detail/components/ReportChat/ReportChat.tsx
@@ -6,11 +6,15 @@ import { useReportLogs } from '../../hooks/useReportLogs';
 import ReportSection from '../common/ReportSection/ReportSection';
 import ChatCard from './ChatCard/ChatCard';
 
-const ReportChat = () => {
+interface Props {
+  viewUUID: string | null;
+}
+
+const ReportChat = ({ viewUUID }: Props) => {
   const { report } = useReportDetailStore();
   const reportId = report?.reportId;
 
-  const { logs, isLoading } = useReportLogs(reportId);
+  const { logs, isLoading } = useReportLogs(reportId, viewUUID);
 
   useEffect(() => {
     if (!reportId) return;

--- a/src/pages/my-report/detail/hooks/useReportDetail.ts
+++ b/src/pages/my-report/detail/hooks/useReportDetail.ts
@@ -7,21 +7,26 @@ import type { ServerApiResponse } from '@/types/api/server.type';
 import { getOrCreateViewUUID } from '../utils/viewUuid';
 
 export const useReportDetail = (reportId?: number) => {
-  const queryConfig = useMemo(() => {
+  const viewUUID = useMemo(() => {
     if (!reportId) return null;
+    return getOrCreateViewUUID(`report-${reportId}`);
+  }, [reportId]);
 
-    const viewUUID = getOrCreateViewUUID(`report-${reportId}`);
+  const queryConfig = useMemo(() => {
+    if (!reportId || !viewUUID) return null;
 
     return {
       method: 'GET',
       url: `/reports/${reportId}`,
       params: { viewUUID },
     };
-  }, [reportId]);
+  }, [reportId, viewUUID]);
 
   const { data, isLoading, isError, error, execute } = useQuery<
     ServerApiResponse<ReportDetailResult>
-  >(queryConfig ?? { method: 'GET', url: '' }, { enabled: Boolean(reportId) });
+  >(queryConfig ?? { method: 'GET', url: '' }, {
+    enabled: Boolean(queryConfig),
+  });
 
   const report = useMemo<ReportDetailResult | null>(() => {
     return data?.result ?? null;
@@ -29,6 +34,7 @@ export const useReportDetail = (reportId?: number) => {
 
   return {
     report,
+    viewUUID, // ✅ 여기서 내려줌
     isLoading,
     isError,
     error,

--- a/src/pages/my-report/detail/hooks/useReportLogs.ts
+++ b/src/pages/my-report/detail/hooks/useReportLogs.ts
@@ -4,24 +4,22 @@ import { useQuery } from '@/hooks/useApi';
 import type { ReportLogsApiResult } from '@/types/api/myreport.type';
 import type { ServerApiResponse } from '@/types/api/server.type';
 
-import { getOrCreateViewUUID } from '../utils/viewUuid';
-
-export const useReportLogs = (reportId?: number) => {
+export const useReportLogs = (reportId?: number, viewUUID?: string | null) => {
   const queryConfig = useMemo(() => {
-    if (!reportId) return null;
-
-    const viewUUID = getOrCreateViewUUID(`report-${reportId}`);
+    if (!reportId || !viewUUID) return null;
 
     return {
       method: 'GET',
       url: `/reports/${reportId}/logs`,
       params: { viewUUID },
     };
-  }, [reportId]);
+  }, [reportId, viewUUID]);
 
   const { data, isLoading, isError, error, execute } = useQuery<
     ServerApiResponse<ReportLogsApiResult>
-  >(queryConfig ?? { method: 'GET', url: '' }, { enabled: Boolean(reportId) });
+  >(queryConfig ?? { method: 'GET', url: '' }, {
+    enabled: Boolean(queryConfig),
+  });
 
   return {
     logs: data?.result.messages ?? [],


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #74 

## 📝 작업 내용
- viewUUID가 useReportDetail, useReportLogs에서 각각 생성되던 문제 수정
- useReportDetail에서만 UUID를 생성하도록 구조 변경
- useReportLogs는 viewUUID를 외부에서 전달받도록 수정

## 📌 공유 사항


## ✅ 체크리스트
- [X] Reviewer에 팀원들을 선택 했나요?
- [X] Assignees에 본인을 선택 했나요?
- [X] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [X] 컨벤션을 지키고 있나요?
- [X] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [X] 불필요한 주석이 제거되었나요?
- [X] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated report detail view to properly track and pass session identifiers through the component hierarchy, improving how report data flows between related components and hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->