### PR TITLE
🐛 Fix: OnboardingVideo 모바일 포맷 분기 로직 수정

### DIFF
--- a/src/pages/onboarding/components/OnboardingVideo.tsx
+++ b/src/pages/onboarding/components/OnboardingVideo.tsx
@@ -25,7 +25,10 @@ const OnboardingVideo = ({
 
   const isMobile = useMemo(() => {
     if (typeof navigator === 'undefined') return false;
-    return /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+    return (
+      /iPhone|iPad|iPod|Android/i.test(navigator.userAgent) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+    );
   }, []);
 
   const usingWebm = !isMobile && !!webmSrc;

--- a/src/pages/onboarding/components/OnboardingVideo.tsx
+++ b/src/pages/onboarding/components/OnboardingVideo.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 type OnboardingVideoProps = {
   webmSrc?: string;
   mp4Src?: string;
   fallbackSrc: string;
   isActive: boolean;
-  widthClass?: string;
+
+  webmWidthClass?: string;
+  mp4WidthClass?: string;
   fallbackWidthClass?: string;
 };
 
@@ -14,11 +16,19 @@ const OnboardingVideo = ({
   mp4Src,
   fallbackSrc,
   isActive,
-  widthClass = 'w-full',
-  fallbackWidthClass,
+  webmWidthClass = 'w-full',
+  mp4WidthClass = 'w-full',
+  fallbackWidthClass = 'w-full',
 }: OnboardingVideoProps) => {
   const ref = useRef<HTMLVideoElement>(null);
   const [hasError, setHasError] = useState(false);
+
+  const isMobile = useMemo(() => {
+    if (typeof navigator === 'undefined') return false;
+    return /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+  }, []);
+
+  const usingWebm = !isMobile && !!webmSrc;
 
   useEffect(() => {
     const video = ref.current;
@@ -26,12 +36,9 @@ const OnboardingVideo = ({
 
     if (isActive) {
       video.currentTime = 0;
-      video
-        .play()
-        .then(() => {})
-        .catch(() => {
-          setHasError(true);
-        });
+      video.play().catch(() => {
+        setHasError(true);
+      });
     } else {
       video.pause();
     }
@@ -42,7 +49,7 @@ const OnboardingVideo = ({
       <img
         src={fallbackSrc}
         alt="fallback"
-        className={`${fallbackWidthClass ?? widthClass} h-auto`}
+        className={`${fallbackWidthClass} h-auto`}
       />
     );
   }
@@ -59,12 +66,12 @@ const OnboardingVideo = ({
       controls={false}
       disablePictureInPicture
       controlsList="nodownload nofullscreen noremoteplayback"
-      className={`${widthClass} h-auto`}
+      className={`${usingWebm ? webmWidthClass : mp4WidthClass} h-auto`}
       onError={() => setHasError(true)}
     >
-      {webmSrc && <source src={webmSrc} type="video/webm" />}
+      {!isMobile && webmSrc && <source src={webmSrc} type="video/webm" />}
+
       {mp4Src && <source src={mp4Src} type="video/mp4" />}
-      <img src={fallbackSrc} alt="fallback" />
     </video>
   );
 };

--- a/src/pages/onboarding/components/Step/Step1.tsx
+++ b/src/pages/onboarding/components/Step/Step1.tsx
@@ -19,7 +19,8 @@ const Step1 = ({ onNext }: Step1Props) => {
           mp4Src={step1Video}
           fallbackSrc={step1Default}
           isActive={true}
-          widthClass="w-[100%]"
+          mp4WidthClass="w-[75%]"
+          webmWidthClass="w-full"
           fallbackWidthClass="w-[80%]"
         />
       </div>

--- a/src/pages/onboarding/components/Step/Step3.tsx
+++ b/src/pages/onboarding/components/Step/Step3.tsx
@@ -36,7 +36,8 @@ const Step3 = ({ onNext }: Step3Props) => {
             mp4Src={step3Video}
             fallbackSrc={step3Default}
             isActive={true}
-            widthClass="w-full"
+            mp4WidthClass="w-full"
+            webmWidthClass="w-full"
           />
         </div>
 

--- a/src/pages/onboarding/components/Step/Step5.tsx
+++ b/src/pages/onboarding/components/Step/Step5.tsx
@@ -27,7 +27,8 @@ const Step5 = () => {
           mp4Src={step5Video}
           fallbackSrc={step5Default}
           isActive={true}
-          widthClass="w-[76%]"
+          mp4WidthClass="w-[75%]"
+          webmWidthClass="w-[76%]"
         />
         <div className="w-full px-[4rem]">
           <button


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close #97 

## 📝 작업 내용
- 모바일 환경에서 WebM 대신 MP4를 사용하도록 분기 처리
- OnboardingVideo에서 포맷별 widthClass 분리 적용

## 📌 공유 사항

## ✅ 체크리스트
- [X] Reviewer에 팀원들을 선택 했나요?
- [X] Assignees에 본인을 선택 했나요?
- [X] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [X] 컨벤션을 지키고 있나요?
- [X] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [X] 불필요한 주석이 제거되었나요?
- [X] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

https://github.com/user-attachments/assets/1412d734-85c9-4aa4-b961-74bdbe43b899


## 💬 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Smarter format selection for video playback to favor compatible formats on mobile for smoother start and reduced bandwidth.
  * Finer responsive control so video sizes adapt per format for more consistent layout across screens.

* **Bug Fixes**
  * More reliable playback with simplified error handling and a consistent image fallback when video fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->