### PR TITLE
🐛 Fix: fallback 이미지 크기 수정

### DIFF
--- a/src/pages/onboarding/components/Step/Step5.tsx
+++ b/src/pages/onboarding/components/Step/Step5.tsx
@@ -29,6 +29,7 @@ const Step5 = () => {
           isActive={true}
           mp4WidthClass="w-[75%]"
           webmWidthClass="w-[76%]"
+          fallbackWidthClass="w-[76%]"
         />
         <div className="w-full px-[4rem]">
           <button


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #97 

## 📝 작업 내용
- step5의 fallback 이미지 크기 수정했습니다.

## 📌 공유 사항
- 소셜 로그인때문에 미리보기 배포로 확인이 불가하여 계속 PR 올리는 점 죄송합니다..

## ✅ 체크리스트
- [X] Reviewer에 팀원들을 선택 했나요?
- [X] Assignees에 본인을 선택 했나요?
- [X] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [X] 컨벤션을 지키고 있나요?
- [X] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [X] 불필요한 주석이 제거되었나요?
- [X] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="345" height="698" alt="IMG_8355" src="https://github.com/user-attachments/assets/bf1cbc04-217b-4846-98f0-b318e0e65aed" />

## 💬 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced onboarding video fallback media styling with improved width customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->